### PR TITLE
Update Docker image to Python 3.12 on Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,14 @@ ARG REF_NAME=""
 # the correct version.
 RUN echo "REF_NAME: $REF_NAME"
 
-RUN python3.12 -m pip install --break-system-packages --upgrade pip setuptools pip-tools && \
-  python3.12 -m pip install --break-system-packages /src/${PROJECT}
+# Use a virtual environment so we don't fight Ubuntu 24.04's externally-managed
+# system Python (PEP 668), which blocks upgrading the Debian-provided pip.
+RUN python3.12 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
-RUN python3.12 -m unittest discover
+RUN pip install --upgrade pip setuptools pip-tools && \
+  pip install /src/${PROJECT}
 
-ENTRYPOINT ["python3.12", "-m", "napari"]
+RUN python -m unittest discover
+
+ENTRYPOINT ["python", "-m", "napari"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ To pull and run a Docker image:
 docker run ghcr.io/czbiohub-sf/compmicro-ndutils-env:v${RELEASE_VERSION}
 ```
 
+Inside the image the environment is installed into a Python virtual environment located at `/opt/venv` (added to the `PATH`, so `python` and `pip` resolve to it by default). To use it explicitly, activate it with `source /opt/venv/bin/activate`.
+
 ### Apptainer
 To run an Apptainer container created from the Docker image:
 ```


### PR DESCRIPTION
Switch the base image to ubuntu:24.04 (ships Python 3.12), rename the GL libraries that changed in 24.04, and install the package into a virtualenv at /opt/venv to avoid PEP 668 externally-managed conflicts with the Debian-provided pip. Document the venv location in the README.